### PR TITLE
Remove YNH panel what's breaking Keeweb content display Issue #25

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,7 +9,4 @@ location __PATH__/ {
 #	default_type text/html;
 
 	more_set_headers "Content-Security-Policy : default-src 'self'; font-src data:; script-src __DOMAIN__ 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline' __DOMAIN__ blob:; connect-src 'self' ws: https:; child-src 'self' blob:; worker-src 'self' blob:; img-src 'self' data: blob: https://services.keeweb.info/; object-src 'none'; form-action 'none';";
-
-	# Include SSOWAT user panel.
-	include conf.d/yunohost_panel.conf.inc;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Password manager compatible with KeePass.",
 		"fr": "Gestionnaire de mots de passe compatible avec KeePass."
 	},
-	"version": "1.18.7~ynh1",
+	"version": "1.18.8~ynh1",
 	"url": "https://keeweb.info/",
 	"license": "MIT",
 	"maintainer": {


### PR DESCRIPTION
## Problem

- Issue #25 

## Solution

-Inclusion of ynh_panel breaks Keeweb content display (and overlay doesn't have its place on a security app anyway)
==> Removed inclusion

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
